### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ module "lb-public-agents" {
 |------|-------------|:----:|:-----:|:-----:|
 | additional_rules | List of additional rules | string | `<list>` | no |
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
+| instance_nic_ids | List of instance nic ids created by this module | list | - | yes |
+| ip_configuration_names | List of ip configuration names associated with the instance nic ids | list | - | yes |
 | location | Azure Region | string | - | yes |
+| num | How many instances should be created | string | - | yes |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,9 @@ module "public-agents" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
+  instance_nic_ids       = ["${var.instance_nic_ids}"]
+  ip_configuration_names = ["${var.ip_configuration_names}"]
+
   lb_name_format = "ext-%[1]s"
 
   providers = {
@@ -46,6 +49,8 @@ module "public-agents" {
     protocol     = "Http"
     request_path = "/_haproxy_health_check"
   }
+
+  num = "${var.num}"
 
   tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,16 @@ variable "resource_group_name" {
   description = "Name of the azure resource group"
 }
 
+variable "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  type        = "list"
+}
+
+variable "ip_configuration_names" {
+  description = "List of ip configuration names associated with the instance nic ids"
+  type        = "list"
+}
+
 variable "location" {
   description = "Azure Region"
 }
@@ -19,4 +29,9 @@ variable "tags" {
 variable "additional_rules" {
   description = "List of additional rules"
   default     = []
+}
+
+# Number of Instance
+variable "num" {
+  description = "How many instances should be created"
 }


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`